### PR TITLE
Add missing required field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,5 @@
 name=Surilli_MQTT_Library
+version=0.0.0
 author=Muhammad Umair
 maintainer=Umair (muhammad.umair@silverback.com.pk)
 sentence=Allows MQTT possible with Surilli GSM


### PR DESCRIPTION
When a required field is missing the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format